### PR TITLE
[#1] Error https status codes should not throw

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## [1.2.0] - 19-06-2020
+
+- fix: 4xx and 5xx http status codes should not throw.
+
 ## [1.1.5] - 19-06-2020
 
 - feat: add repository to `egg.json`.

--- a/egg.json
+++ b/egg.json
@@ -1,7 +1,7 @@
 {
     "name": "superdeno",
     "description": "HTTP assertions for Deno made easy via superagent.",
-    "version": "1.1.5",
+    "version": "1.2.0",
     "repository": "https://github.com/asos-craigmorten/superdeno",
     "stable": true,
     "files": [

--- a/src/test.ts
+++ b/src/test.ts
@@ -401,7 +401,10 @@ export class Test extends SuperRequest {
     }
 
     // set unexpected superagent error if no other error has occurred.
-    if (!error && resError instanceof Error && (!res || (resError as any).status !== res.status)) {
+    if (
+      !error && resError instanceof Error &&
+      (!res || (resError as any).status !== res.status)
+    ) {
       error = resError;
     }
 

--- a/src/test.ts
+++ b/src/test.ts
@@ -395,11 +395,13 @@ export class Test extends SuperRequest {
       error = resError;
     }
 
+    // asserts
     for (let i = 0; i < this.#asserts.length && !error; i += 1) {
       error = this.#assertFunction(this.#asserts[i], res);
     }
 
-    if (!error && resError) {
+    // set unexpected superagent error if no other error has occurred.
+    if (!error && resError instanceof Error && (!res || (resError as any).status !== res.status)) {
       error = resError;
     }
 

--- a/test/supertest.opine.test.ts
+++ b/test/supertest.opine.test.ts
@@ -396,7 +396,9 @@ describe("superdeno(app)", () => {
         .end(done);
     });
 
-    it("superdeno(app): .expect(status): should assert only error status'", (done) => {
+    it("superdeno(app): .expect(status): should assert only error status'", (
+      done,
+    ) => {
       const app = opine();
 
       app.get("/", (req: OpineTypes.Request, res: OpineTypes.Response) => {

--- a/test/supertest.opine.test.ts
+++ b/test/supertest.opine.test.ts
@@ -395,6 +395,19 @@ describe("superdeno(app)", () => {
         .expect(200)
         .end(done);
     });
+
+    it("superdeno(app): .expect(status): should assert only error status'", (done) => {
+      const app = opine();
+
+      app.get("/", (req: OpineTypes.Request, res: OpineTypes.Response) => {
+        res.sendStatus(400);
+      });
+
+      superdeno(app)
+        .get("/")
+        .expect(400)
+        .end(done);
+    });
   });
 
   describe(".expect(status, body[, fn])", () => {
@@ -410,6 +423,20 @@ describe("superdeno(app)", () => {
       superdeno(app)
         .get("/")
         .expect(200, "foo", done);
+    });
+
+    it("superdeno(app): .expect(status, body[, fn]): should assert the response body and error status'", (
+      done,
+    ) => {
+      const app = opine();
+
+      app.get("/", (req: OpineTypes.Request, res: OpineTypes.Response) => {
+        res.setStatus(400).send("foo");
+      });
+
+      superdeno(app)
+        .get("/")
+        .expect(400, "foo", done);
     });
 
     describe("when the body argument is an empty string", () => {

--- a/version.ts
+++ b/version.ts
@@ -1,7 +1,7 @@
 /** 
  * Version of Opine.
  */
-export const VERSION: string = "1.1.5";
+export const VERSION: string = "1.2.0";
 
 /**
  * Supported versions of Deno.


### PR DESCRIPTION
# Issue

[#1](https://github.com/asos-craigmorten/superdeno/issues/1)

## Details

Fixes a bug whereby error http status code, i.e 4xx, 5xx etc. are throwing errors when they should not be.

## CheckList

- [x] PR starts with [#_ISSUE_ID_].
- [x] Has been tested (where required) before merge to develop.
