### PR TITLE
[#10] SuperDeno should permit and handle GET requests with body payloads.

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## [1.6.1] - 06-07-2020
+
+- fix: SuperDeno should permit and handle GET requests with body payloads.
+
 ## [1.6.0] - 06-07-2020
 
 - feat: bump deno and deps versions.

--- a/egg.json
+++ b/egg.json
@@ -1,7 +1,7 @@
 {
     "name": "superdeno",
     "description": "HTTP assertions for Deno made easy via superagent.",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "repository": "https://github.com/asos-craigmorten/superdeno",
     "stable": true,
     "files": [

--- a/src/xhrSham.js
+++ b/src/xhrSham.js
@@ -258,6 +258,11 @@ export class XMLHttpRequestSham {
       return xhr.onreadystatechange();
     } else {
       try {
+        const body = typeof options.requestBody === "object" &&
+          options.requestBody !== null
+          ? JSON.stringify(options.requestBody)
+          : options.requestBody;
+
         // We should the fetch promise into a polyfill promise cache
         // so that superdeno can await these promises before ending.
         // Not doing such results in Deno test complaining of unhandled
@@ -265,8 +270,9 @@ export class XMLHttpRequestSham {
         window._xhrSham.promises[self.id] = fetch(options.url, {
           method: options.method,
           headers: options.requestHeaders,
-          body: options.requestBody,
+          body,
           signal: this.controller.signal,
+          mode: "cors",
         });
 
         // Wait on the response, and then read the buffer.

--- a/test/supertest.opine.test.ts
+++ b/test/supertest.opine.test.ts
@@ -128,7 +128,7 @@ describe("superdeno(app)", () => {
   //     });
   // });
 
-  it("superdeno(app): should work with .send() etc", (done) => {
+  it("superdeno(app): should work with .send() on POST", (done) => {
     const app = opine();
 
     app.use(json());
@@ -139,6 +139,23 @@ describe("superdeno(app)", () => {
 
     superdeno(app)
       .post("/")
+      .send({ name: "john" })
+      .expect("john", done);
+  });
+
+  it("superdeno(app): should work with .send() on GET given RFCs 7230-7237", (
+    done,
+  ) => {
+    const app = opine();
+
+    app.use(json());
+
+    app.get("/", (req: OpineTypes.Request, res: OpineTypes.Response) => {
+      res.send(req.parsedBody.name);
+    });
+
+    superdeno(app)
+      .get("/")
       .send({ name: "john" })
       .expect("john", done);
   });

--- a/version.ts
+++ b/version.ts
@@ -1,7 +1,7 @@
 /** 
  * Version of Opine.
  */
-export const VERSION: string = "1.6.0";
+export const VERSION: string = "1.6.1";
 
 /**
  * Supported versions of Deno.


### PR DESCRIPTION
# Issue

[#10](https://github.com/asos-craigmorten/superdeno/issues/10)

## Details

Properly parse request body in `fetch`.

## CheckList

- [ ] PR starts with [#_ISSUE_ID_].
- [ ] Has been tested (where required) before merge to develop.
