### PR TITLE
[#6] Support redirects api

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ChangeLog
 
+## [3.0.0] - 12-12-2020
+
+- feat: **BREAKING CHANGE** support [superagent `.redirects(n)` API](https://visionmedia.github.io/superagent/#following-redirects), with a default of `0`.
+
+The consequence of supporting the `.redirects(n)` API is that superdeno follows a default of `0` redirects, for parity with [supertest](https://github.com/visionmedia/supertest/blob/master/lib/test.js#L32). If your test requires superdeno to follow multiple redirects, specify the number of redirects required in `.redirects(n)`, or use `-1` to have superdeno follow all redirects.
+
 ## [2.5.0] - 10-12-2020
 
 - feat: update to Deno `1.6.0`, std `0.80.0` and other dep upgrades.

--- a/.github/workflows/publish-egg.yml
+++ b/.github/workflows/publish-egg.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: denolib/setup-deno@v2
         with:
           deno-version: 1.6.0
-      - run: deno install -A -f --unstable -n eggs https://x.nest.land/eggs@0.3.3/mod.ts
+      - run: deno install -A -f --unstable -n eggs https://x.nest.land/eggs@0.3.3/eggs.ts
       - run: |
           export PATH="/home/runner/.deno/bin:$PATH"
           eggs link ${NEST_LAND_KEY}

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ HTTP assertions for Deno made easy via <a href="https://github.com/visionmedia/s
 ## Getting Started
 
 ```ts
-import { superdeno } from "https://deno.land/x/superdeno@2.5.0/mod.ts";
+import { superdeno } from "https://deno.land/x/superdeno@3.0.0/mod.ts";
 import { opine } from "https://deno.land/x/opine@0.22.1/mod.ts";
 
 const app = opine();
@@ -69,13 +69,13 @@ Before importing, [download and install Deno](https://deno.land/#installation).
 You can then import SuperDeno straight into your project:
 
 ```ts
-import { superdeno } from "https://deno.land/x/superdeno@2.5.0/mod.ts";
+import { superdeno } from "https://deno.land/x/superdeno@3.0.0/mod.ts";
 ```
 
 SuperDeno is also available on [nest.land](https://nest.land/package/superdeno), a package registry for Deno on the Blockchain.
 
 ```ts
-import { superdeno } from "https://x.nest.land/superdeno@2.5.0/mod.ts";
+import { superdeno } from "https://x.nest.land/superdeno@3.0.0/mod.ts";
 ```
 
 ## Example
@@ -98,7 +98,7 @@ Here's an example of SuperDeno working with the Opine web framework:
 
 ```ts
 import { opine } from "https://deno.land/x/opine@0.22.1/mod.ts";
-import { superdeno } from "https://deno.land/x/superdeno@2.5.0/mod.ts";
+import { superdeno } from "https://deno.land/x/superdeno@3.0.0/mod.ts";
 export { expect } from "https://x.nest.land/expect@0.2.4/mod.ts";
 
 const app = opine();
@@ -123,7 +123,7 @@ Here's an example of SuperDeno working with the Oak web framework:
 
 ```ts
 import { Application, Router } from "https://deno.land/x/oak@v6.2.0/mod.ts";
-import { superdeno } from "https://deno.land/x/superdeno@2.5.0/mod.ts";
+import { superdeno } from "https://deno.land/x/superdeno@3.0.0/mod.ts";
 
 const router = new Router();
 router.get("/", (ctx) => {
@@ -159,7 +159,7 @@ If you don't need to test the server setup side of your Oak application, or you 
 
 ```ts
 import { Application, Router } from "https://deno.land/x/oak@v6.2.0/mod.ts";
-import { superdeno } from "https://deno.land/x/superdeno@2.5.0/mod.ts";
+import { superdeno } from "https://deno.land/x/superdeno@3.0.0/mod.ts";
 
 const router = new Router();
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -99,7 +99,7 @@
 				<a href="#getting-started" id="getting-started" style="color: inherit; text-decoration: none;">
 					<h2>Getting Started</h2>
 				</a>
-				<pre><code class="language-ts"><span class="hljs-keyword">import</span> { superdeno } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://deno.land/x/superdeno@2.5.0/mod.ts&quot;</span>;
+				<pre><code class="language-ts"><span class="hljs-keyword">import</span> { superdeno } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://deno.land/x/superdeno@3.0.0/mod.ts&quot;</span>;
 <span class="hljs-keyword">import</span> { opine } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://deno.land/x/opine@0.22.1/mod.ts&quot;</span>;
 
 <span class="hljs-keyword">const</span> app = opine();
@@ -127,9 +127,9 @@ superdeno(app)
 				<p>This is a <a href="https://deno.land/">Deno</a> module available to import direct from this repo and via the <a href="https://deno.land/x">Deno Registry</a>.</p>
 				<p>Before importing, <a href="https://deno.land/#installation">download and install Deno</a>.</p>
 				<p>You can then import SuperDeno straight into your project:</p>
-				<pre><code class="language-ts"><span class="hljs-keyword">import</span> { superdeno } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://deno.land/x/superdeno@2.5.0/mod.ts&quot;</span>;</code></pre>
+				<pre><code class="language-ts"><span class="hljs-keyword">import</span> { superdeno } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://deno.land/x/superdeno@3.0.0/mod.ts&quot;</span>;</code></pre>
 				<p>SuperDeno is also available on <a href="https://nest.land/package/superdeno">nest.land</a>, a package registry for Deno on the Blockchain.</p>
-				<pre><code class="language-ts"><span class="hljs-keyword">import</span> { superdeno } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://x.nest.land/superdeno@2.5.0/mod.ts&quot;</span>;</code></pre>
+				<pre><code class="language-ts"><span class="hljs-keyword">import</span> { superdeno } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://x.nest.land/superdeno@3.0.0/mod.ts&quot;</span>;</code></pre>
 				<a href="#example" id="example" style="color: inherit; text-decoration: none;">
 					<h2>Example</h2>
 				</a>
@@ -144,7 +144,7 @@ superdeno(app)
 });</code></pre>
 				<p>Here&#39;s an example of SuperDeno working with the Opine web framework:</p>
 				<pre><code class="language-ts"><span class="hljs-keyword">import</span> { opine } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://deno.land/x/opine@0.22.1/mod.ts&quot;</span>;
-<span class="hljs-keyword">import</span> { superdeno } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://deno.land/x/superdeno@2.5.0/mod.ts&quot;</span>;
+<span class="hljs-keyword">import</span> { superdeno } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://deno.land/x/superdeno@3.0.0/mod.ts&quot;</span>;
 <span class="hljs-keyword">export</span> { expect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://x.nest.land/expect@0.2.4/mod.ts&quot;</span>;
 
 <span class="hljs-keyword">const</span> app = opine();
@@ -165,7 +165,7 @@ Deno.test(<span class="hljs-string">&quot;it should support regular expressions&
 });</code></pre>
 				<p>Here&#39;s an example of SuperDeno working with the Oak web framework:</p>
 				<pre><code class="language-ts"><span class="hljs-keyword">import</span> { Application, Router } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://deno.land/x/oak@v6.2.0/mod.ts&quot;</span>;
-<span class="hljs-keyword">import</span> { superdeno } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://deno.land/x/superdeno@2.5.0/mod.ts&quot;</span>;
+<span class="hljs-keyword">import</span> { superdeno } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://deno.land/x/superdeno@3.0.0/mod.ts&quot;</span>;
 
 <span class="hljs-keyword">const</span> router = <span class="hljs-keyword">new</span> Router();
 router.get(<span class="hljs-string">&quot;/&quot;</span>, <span class="hljs-function">(<span class="hljs-params">ctx</span>) =&gt;</span> {
@@ -196,7 +196,7 @@ Deno.test(<span class="hljs-string">&quot;it should support the Oak framework&qu
 				<p>If you are using the <a href="https://github.com/oakserver/oak/">Oak</a> web framework then it is recommended that you use the specialized <a href="https://github.com/asos-craigmorten/superoak">SuperOak</a> assertions library for reduced bootstrapping.</p>
 				<p>If you don&#39;t need to test the server setup side of your Oak application, or you are making use of the <code>app.handle()</code> method (for example for serverless apps) then you can write slightly less verbose tests for Oak:</p>
 				<pre><code class="language-ts"><span class="hljs-keyword">import</span> { Application, Router } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://deno.land/x/oak@v6.2.0/mod.ts&quot;</span>;
-<span class="hljs-keyword">import</span> { superdeno } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://deno.land/x/superdeno@2.5.0/mod.ts&quot;</span>;
+<span class="hljs-keyword">import</span> { superdeno } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://deno.land/x/superdeno@3.0.0/mod.ts&quot;</span>;
 
 <span class="hljs-keyword">const</span> router = <span class="hljs-keyword">new</span> Router();
 

--- a/egg.json
+++ b/egg.json
@@ -1,7 +1,7 @@
 {
     "name": "superdeno",
     "description": "HTTP assertions for Deno made easy via superagent.",
-    "version": "2.5.0",
+    "version": "3.0.0",
     "repository": "https://github.com/asos-craigmorten/superdeno",
     "stable": true,
     "files": [

--- a/src/test.ts
+++ b/src/test.ts
@@ -343,6 +343,11 @@ export class Test extends SuperRequest {
     delete (this as any).req;
     delete (this as any)._formData;
 
+    // TODO: headers
+    // TODO: origin change
+    // TODO: 3xx specific changes
+    // REF: https://github.com/visionmedia/superagent/blob/master/src/node/index.js#L477
+
     this.url = new URL(url, this.url).href;
     (this as any)._fullfilledPromise = Promise.resolve();
     (this as any)._endCalled = false;

--- a/src/xhrSham.js
+++ b/src/xhrSham.js
@@ -263,7 +263,7 @@ export class XMLHttpRequestSham {
           ? JSON.stringify(options.requestBody)
           : options.requestBody;
 
-        // We should the fetch promise into a polyfill promise cache
+        // We set the fetch promise into a polyfill promise cache
         // so that superdeno can await these promises before ending.
         // Not doing such results in Deno test complaining of unhandled
         // async operations.
@@ -273,6 +273,14 @@ export class XMLHttpRequestSham {
           body,
           signal: this.controller.signal,
           mode: "cors",
+          // Deviations from the fetch spec (https://fetch.spec.whatwg.org/)
+          // allow us to implement redirect logic into superdeno
+          // via the `manual` redirect setting, which returns a
+          // `basic` response instead of a `opaqueredirect` one.
+          // REF:
+          // - https://github.com/denoland/deno/pull/8353
+          // - https://deno.land/manual/runtime/web_platform_apis#spec-deviations
+          redirect: "manual",
         });
 
         // Wait on the response, and then read the buffer.

--- a/src/xhrSham.js
+++ b/src/xhrSham.js
@@ -2,9 +2,20 @@ import { mergeDescriptors } from "../deps.ts";
 
 const decoder = new TextDecoder("utf-8");
 
-window._xhrSham = window._xhrSham || {};
-window._xhrSham.idSequence = 0;
-window._xhrSham.promises = {};
+let SHAM_SYMBOL = Symbol("SHAM_SYMBOL");
+
+function setupSham(symbol) {
+  window[symbol] = window[symbol] || {};
+  window[symbol].idSequence = 0;
+  window[symbol].promises = {};
+}
+
+setupSham(SHAM_SYMBOL);
+
+export const exposeSham = (symbol) => {
+  SHAM_SYMBOL = symbol;
+  setupSham(SHAM_SYMBOL);
+};
 
 /**
  * A polyfill for XMLHttpRequest.
@@ -15,7 +26,7 @@ window._xhrSham.promises = {};
  */
 export class XMLHttpRequestSham {
   constructor() {
-    this.id = (++window._xhrSham.idSequence).toString(36);
+    this.id = (++window[SHAM_SYMBOL].idSequence).toString(36);
     this.origin = null;
     this.onreadystatechange = () => {};
     this.readyState = 0;
@@ -195,7 +206,7 @@ export class XMLHttpRequestSham {
       // in this implementation. TBC whether this is accurate.
       // To prevent a memory leak we clean up our promise from the
       // cache now that it _must_ be resolved.
-      delete window._xhrSham.promises[self.id];
+      delete window[SHAM_SYMBOL].promises[self.id];
 
       xhrResponse.responseHeaders = xhrResponse.getAllResponseHeaders();
       onStateChange(xhrResponse);
@@ -267,7 +278,7 @@ export class XMLHttpRequestSham {
         // so that superdeno can await these promises before ending.
         // Not doing such results in Deno test complaining of unhandled
         // async operations.
-        window._xhrSham.promises[self.id] = fetch(options.url, {
+        window[SHAM_SYMBOL].promises[self.id] = fetch(options.url, {
           method: options.method,
           headers: options.requestHeaders,
           body,
@@ -284,7 +295,7 @@ export class XMLHttpRequestSham {
         });
 
         // Wait on the response, and then read the buffer.
-        response = await window._xhrSham.promises[self.id];
+        response = await window[SHAM_SYMBOL].promises[self.id];
 
         mergeDescriptors(xhr, response, false);
 

--- a/test/deps.ts
+++ b/test/deps.ts
@@ -1,5 +1,4 @@
 export { dirname, join } from "https://deno.land/std@0.80.0/path/mod.ts";
 export { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 export * as Opine from "https://deno.land/x/opine@0.27.0/mod.ts";
-export * as OpineTypes from "https://deno.land/x/opine@0.27.0/src/types.ts";
 export * as Oak from "https://deno.land/x/oak@v6.3.2/mod.ts";

--- a/test/deps.ts
+++ b/test/deps.ts
@@ -2,3 +2,4 @@ export { dirname, join } from "https://deno.land/std@0.80.0/path/mod.ts";
 export { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 export * as Opine from "https://deno.land/x/opine@0.27.0/mod.ts";
 export * as Oak from "https://deno.land/x/oak@v6.3.2/mod.ts";
+export { getFreePort } from "https://deno.land/x/free_port@v1.2.0/mod.ts";

--- a/test/redirects-other-host.test.ts
+++ b/test/redirects-other-host.test.ts
@@ -1,0 +1,253 @@
+import { expect, Opine } from "./deps.ts";
+import { Server } from "../deps.ts";
+import { describe, it } from "./utils.ts";
+import { superdeno } from "../mod.ts";
+const { opine } = Opine;
+
+let server: Server;
+let address: Deno.NetAddr;
+let base: string;
+
+let server2: Server;
+let address2: Deno.NetAddr;
+let base2: string;
+
+const setup = () => {
+  const app = opine();
+  const app2 = opine();
+
+  app.use((req, res, next) => {
+    res.set("Host", base);
+    next();
+  });
+  app.all("/test-301", (req, res) => {
+    res.redirect(301, `${base2}/`);
+  });
+  app.all("/test-302", (req, res) => {
+    res.redirect(302, `${base2}/`);
+  });
+  app.all("/test-303", (req, res) => {
+    res.redirect(303, `${base2}/`);
+  });
+  app.all("/test-307", (req, res) => {
+    res.redirect(307, `${base2}/`);
+  });
+  app.all("/test-308", (req, res) => {
+    res.redirect(308, `${base2}/`);
+  });
+
+  app2.use((req, res, next) => {
+    res.set("Host", base2);
+    next();
+  });
+  app2.all("/", (req, res) => {
+    res.send(req.method);
+  });
+
+  server = app.listen();
+  address = server.listener.addr as Deno.NetAddr;
+  base = `http://localhost:${address.port}`;
+
+  server2 = app2.listen();
+  address2 = server2.listener.addr as Deno.NetAddr;
+  base2 = `http://localhost:${address2.port}`;
+};
+
+const teardown = () => {
+  server?.close?.();
+  server2?.close?.();
+};
+
+describe("request.get", () => {
+  describe("on 301 redirect", () => {
+    it("request.get: on 301 redirect: should follow Location with a GET request", (
+      done,
+    ) => {
+      setup();
+
+      superdeno(base)
+        .get("/test-301")
+        .redirects(1)
+        .end((err, res) => {
+          expect(res.header.host).toEqual(base2);
+          expect(res.status).toEqual(200);
+          expect(res.text).toEqual("GET");
+          teardown();
+          done();
+        });
+    });
+  });
+
+  describe("on 302 redirect", () => {
+    it("request.get: on 302 redirect: should follow Location with a GET request", (
+      done,
+    ) => {
+      setup();
+
+      superdeno(base)
+        .get("/test-302")
+        .redirects(1)
+        .end((err, res) => {
+          expect(res.header.host).toEqual(base2);
+          expect(res.status).toEqual(200);
+          expect(res.text).toEqual("GET");
+          teardown();
+          done();
+        });
+    });
+  });
+
+  describe("on 303 redirect", () => {
+    it("request.get: on 303 redirect: should follow Location with a GET request", (
+      done,
+    ) => {
+      setup();
+
+      superdeno(base)
+        .get("/test-303")
+        .redirects(1)
+        .end((err, res) => {
+          expect(res.header.host).toEqual(base2);
+          expect(res.status).toEqual(200);
+          expect(res.text).toEqual("GET");
+          teardown();
+          done();
+        });
+    });
+  });
+
+  describe("on 307 redirect", () => {
+    it("request.get: on 307 redirect: should follow Location with a GET request", (
+      done,
+    ) => {
+      setup();
+
+      superdeno(base)
+        .get("/test-307")
+        .redirects(1)
+        .end((err, res) => {
+          expect(res.header.host).toEqual(base2);
+          expect(res.status).toEqual(200);
+          expect(res.text).toEqual("GET");
+          teardown();
+          done();
+        });
+    });
+  });
+
+  describe("on 308 redirect", () => {
+    it("request.get: on 308 redirect: should follow Location with a GET request", (
+      done,
+    ) => {
+      setup();
+
+      superdeno(base)
+        .get("/test-308")
+        .redirects(1)
+        .end((err, res) => {
+          expect(res.header.host).toEqual(base2);
+          expect(res.status).toEqual(200);
+          expect(res.text).toEqual("GET");
+          teardown();
+          done();
+        });
+    });
+  });
+});
+
+describe("request.post", () => {
+  describe("on 301 redirect", () => {
+    it("request.post: on 301 redirect: should follow Location with a GET request", (
+      done,
+    ) => {
+      setup();
+
+      superdeno(base)
+        .post("/test-301")
+        .redirects(1)
+        .end((err, res) => {
+          expect(res.header.host).toEqual(base2);
+          expect(res.status).toEqual(200);
+          expect(res.text).toEqual("GET");
+          teardown();
+          done();
+        });
+    });
+
+    describe("on 302 redirect", () => {
+      it("request.post: on 302 redirect: should follow Location with a GET request", (
+        done,
+      ) => {
+        setup();
+
+        superdeno(base)
+          .post("/test-302")
+          .redirects(1)
+          .end((err, res) => {
+            expect(res.header.host).toEqual(base2);
+            expect(res.status).toEqual(200);
+            expect(res.text).toEqual("GET");
+            teardown();
+            done();
+          });
+      });
+    });
+
+    describe("on 303 redirect", () => {
+      it("request.post: on 303 redirect: should follow Location with a GET request", (
+        done,
+      ) => {
+        setup();
+
+        superdeno(base)
+          .post("/test-303")
+          .redirects(1)
+          .end((err, res) => {
+            expect(res.header.host).toEqual(base2);
+            expect(res.status).toEqual(200);
+            expect(res.text).toEqual("GET");
+            teardown();
+            done();
+          });
+      });
+    });
+
+    describe("on 307 redirect", () => {
+      it("request.post: on 307 redirect: should follow Location with a POST request", (
+        done,
+      ) => {
+        setup();
+
+        superdeno(base)
+          .post("/test-307")
+          .redirects(1)
+          .end((err, res) => {
+            expect(res.header.host).toEqual(base2);
+            expect(res.status).toEqual(200);
+            expect(res.text).toEqual("POST");
+            teardown();
+            done();
+          });
+      });
+    });
+
+    describe("on 308 redirect", () => {
+      it("request.post: on 308 redirect: should follow Location with a POST request", (
+        done,
+      ) => {
+        setup();
+
+        superdeno(base)
+          .post("/test-308")
+          .redirects(1)
+          .end((err, res) => {
+            expect(res.header.host).toEqual(base2);
+            expect(res.status).toEqual(200);
+            expect(res.text).toEqual("POST");
+            teardown();
+            done();
+          });
+      });
+    });
+  });
+});

--- a/test/redirects.test.ts
+++ b/test/redirects.test.ts
@@ -1,0 +1,541 @@
+import { expect, Opine } from "./deps.ts";
+import { describe, it } from "./utils.ts";
+import { superdeno } from "../mod.ts";
+
+const { opine, json, urlencoded } = Opine;
+let promises: Promise<any>[] = [];
+
+const allPromises = async () => {
+  for (const promise of promises) {
+    try {
+      await promise;
+    } catch (e) {}
+  }
+  promises = [];
+};
+
+const setup = () => {
+  const app = opine();
+
+  app.use(json());
+  app.use(urlencoded({ extended: true }));
+
+  app.use((req, res, next) => {
+    res.set("Cache-Control", "no-cache, no-store");
+    next();
+  });
+
+  app.post("/movie", (req, res) => {
+    res.redirect("/movies/all/0");
+  });
+
+  app.get("/", (req, res) => {
+    res.set("QUERY", JSON.stringify(req.query));
+    res.redirect("/movies");
+  });
+
+  app.get("/movies", (req, res) => {
+    res.set("QUERY", JSON.stringify(req.query));
+    res.redirect("/movies/all");
+  });
+
+  app.get("/movies/all", (req, res) => {
+    res.set("QUERY", JSON.stringify(req.query));
+    res.redirect("/movies/all/0");
+  });
+
+  app.get("/movies/all/0", (req, res) => {
+    res.set("QUERY", JSON.stringify(req.query));
+    res.setStatus(200).send("first movie page");
+  });
+
+  app.get("/movies/random", (req, res) => {
+    res.redirect("/movie/4");
+  });
+
+  app.get("/movie/4", (req, res) => {
+    promises.push(
+      new Promise((resolve) =>
+        setTimeout(async () => {
+          try {
+            await res.end("not-so-random movie");
+          } catch (e) {}
+          resolve(true);
+        }, 250)
+      ),
+    );
+  });
+
+  app.get("/cookie-redirect", (req, res) => {
+    res.set("Set-Cookie", "replaced=yes");
+    res.append("Set-Cookie", "from-redir=1");
+    res.redirect(303, "/show-cookies");
+  });
+
+  app.get("/show-cookies", (req, res) => {
+    res.set("content-type", "text/plain");
+    res.send(req.headers.get("cookie"));
+  });
+
+  app.put("/redirect-303", (req, res) => {
+    res.redirect(303, "/reply-method");
+  });
+
+  app.put("/redirect-307", (req, res) => {
+    res.redirect(307, "/reply-method");
+  });
+
+  app.put("/redirect-308", (req, res) => {
+    res.redirect(308, "/reply-method");
+  });
+
+  app.all("/reply-method", (req, res) => {
+    res.send(`method=${req.method.toLowerCase()}`);
+  });
+
+  app.get("/smudgie", (req, res) => {
+    res.send("smudgie");
+  });
+
+  app.get("/relative", (req, res) => {
+    res.redirect("smudgie");
+  });
+
+  app.get("/relative/sub", (req, res) => {
+    res.redirect("../smudgie");
+  });
+
+  app.get("/header", (req, res) => {
+    res.redirect("/header/2");
+  });
+
+  app.post("/header", (req, res) => {
+    res.redirect("/header/2");
+  });
+
+  app.get("/header/2", (req, res) => {
+    res.send(Object.fromEntries(req.headers.entries()));
+  });
+
+  app.get("/bad-redirect", async (req, res) => {
+    try {
+      await res.setStatus(307).end();
+    } catch (e) {}
+  });
+
+  const called: any = {};
+
+  app.get("/error/redirect/:id", (req, res) => {
+    const { id } = req.params;
+    if (!called[id]) {
+      called[id] = true;
+      res.setStatus(500).send("boom");
+    } else {
+      res.redirect("/movies");
+      delete called[id];
+    }
+  });
+
+  return app;
+};
+
+describe("request", function () {
+  describe("on redirect", () => {
+    it("should not follow by default", async () => {
+      const redirects: string[] = [];
+
+      const app = setup();
+
+      await superdeno(app)
+        .get("/")
+        .on("redirect", (res) => {
+          redirects.push(res.headers.location);
+        })
+        .then((res) => {
+          expect(redirects).toEqual([]);
+          expect(res.status).toEqual(302);
+        });
+    });
+
+    it("should follow when redirects are set", (done) => {
+      const redirects: string[] = [];
+
+      const app = setup();
+
+      superdeno(app)
+        .head("/")
+        .redirects(10)
+        .on("redirect", (res) => {
+          redirects.push(res.headers.location);
+        })
+        .end((err, res) => {
+          try {
+            const arr = [];
+            arr.push("/movies");
+            arr.push("/movies/all");
+            arr.push("/movies/all/0");
+            expect(redirects).toEqual(arr);
+            expect(res.text).toBeFalsy();
+            done();
+          } catch (e) {
+            done(e);
+          }
+        });
+    });
+
+    describe("when set to follow all redirects (e.g. `.redirects(-1)`)", () => {
+      it("should retain header fields", (done) => {
+        const app = setup();
+
+        superdeno(app)
+          .get("/header")
+          .set("X-Foo", "bar")
+          .redirects(-1)
+          .end((err, res) => {
+            try {
+              expect(res.body).toBeDefined();
+              expect(res.body["x-foo"]).toEqual("bar");
+              done();
+            } catch (e) {
+              done(e);
+            }
+          });
+      });
+
+      it("should preserve timeout across redirects", (done) => {
+        const app = setup();
+
+        superdeno(app)
+          .get("/movies/random")
+          .redirects(-1)
+          .timeout(100)
+          .end(async (err, res) => {
+            await allPromises();
+
+            try {
+              expect(err).toBeInstanceOf(Error);
+              expect(err.timeout).toEqual(100);
+              done();
+            } catch (e) {
+              done(e);
+            }
+          });
+      });
+
+      it("should successfully redirect after retry on error", (done) => {
+        const id = Math.random() * 1000000 * Date.now();
+
+        const app = setup();
+
+        superdeno(app)
+          .get(`/error/redirect/${id}`)
+          .redirects(-1)
+          .retry(2)
+          .end((err, res) => {
+            expect(res.ok).toBeTruthy();
+            expect(res.text).toEqual("first movie page");
+            done();
+          });
+      });
+
+      it("should not merge cookies", (done) => {
+        const app = setup();
+
+        superdeno(app)
+          .get("/cookie-redirect")
+          .set("Cookie", "orig=1; replaced=not")
+          .redirects(-1)
+          .end((err, res) => {
+            try {
+              expect(err).toBeNull();
+              expect(res.text).toMatch(/orig=1/);
+              expect(res.text).toMatch(/replaced=not/);
+              expect(res.text).not.toMatch(/replaced=yes/);
+              expect(res.text).not.toMatch(/from-redir=1/);
+              done();
+            } catch (e) {
+              done(e);
+            }
+          });
+      });
+
+      it("should follow Location", (done) => {
+        const redirects: string[] = [];
+
+        const app = setup();
+
+        superdeno(app)
+          .get("/")
+          .redirects(-1)
+          .on("redirect", (res) => {
+            redirects.push(res.headers.location);
+          })
+          .end((err, res) => {
+            try {
+              const arr = ["/movies", "/movies/all", "/movies/all/0"];
+              expect(redirects).toEqual(arr);
+              expect(res.text).toEqual("first movie page");
+              done();
+            } catch (e) {
+              done(e);
+            }
+          });
+      });
+
+      it("should remove Content-* fields", (done) => {
+        const app = setup();
+
+        superdeno(app)
+          .post("/header")
+          .redirects(-1)
+          .type("txt")
+          .set("X-Foo", "bar")
+          .set("X-Bar", "baz")
+          .send("hey")
+          .end((err, res) => {
+            try {
+              expect(res.body).not.toBeNull();
+              expect(res.body["x-foo"]).toEqual("bar");
+              expect(res.body["x-bar"]).toEqual("baz");
+              expect(res.body["content-type"]).toBeUndefined();
+              expect(res.body["content-length"]).toBeUndefined();
+              expect(res.body["transfer-encoding"]).toBeUndefined();
+              done();
+            } catch (e) {
+              done(e);
+            }
+          });
+      });
+
+      it("should not resend query parameters", (done) => {
+        const redirects: string[] = [];
+        const query: string[] = [];
+
+        const app = setup();
+
+        superdeno(app)
+          .get("/?foo=bar")
+          .redirects(-1)
+          .on("redirect", (res) => {
+            query.push(res.headers.query);
+            redirects.push(res.headers.location);
+          })
+          .end((err, res) => {
+            try {
+              const arr = [];
+              arr.push("/movies");
+              arr.push("/movies/all");
+              arr.push("/movies/all/0");
+              expect(redirects).toEqual(arr);
+              expect(res.text).toEqual("first movie page");
+              expect(query).toEqual(['{"foo":"bar"}', "{}", "{}"]);
+              expect(res.headers.query).toEqual("{}");
+              done();
+            } catch (e) {
+              done(e);
+            }
+          });
+      });
+
+      it("should handle no location header", (done) => {
+        const app = setup();
+
+        superdeno(app)
+          .get("/bad-redirect")
+          .redirects(-1)
+          .end((err, res) => {
+            try {
+              expect(err.message).toEqual("No location header for redirect");
+              done();
+            } catch (e) {
+              done(e);
+            }
+          });
+      });
+
+      describe("when relative", () => {
+        it("should redirect to a sibling path", (done) => {
+          const redirects: string[] = [];
+
+          const app = setup();
+
+          superdeno(app)
+            .get("/relative")
+            .redirects(-1)
+            .on("redirect", (res) => {
+              redirects.push(res.headers.location);
+            })
+            .end((err, res) => {
+              try {
+                expect(redirects).toEqual(["smudgie"]);
+                expect(res.text).toEqual("smudgie");
+                done();
+              } catch (e) {
+                done(e);
+              }
+            });
+        });
+
+        it("should redirect to a parent path", (done) => {
+          const redirects: string[] = [];
+
+          const app = setup();
+
+          superdeno(app)
+            .get("/relative/sub")
+            .redirects(-1)
+            .on("redirect", (res) => {
+              redirects.push(res.headers.location);
+            })
+            .end((err, res) => {
+              try {
+                expect(redirects).toEqual(["../smudgie"]);
+                expect(res.text).toEqual("smudgie");
+                done();
+              } catch (err_) {
+                done(err_);
+              }
+            });
+        });
+      });
+    });
+  });
+
+  describe("req.redirects(n)", () => {
+    it("should alter the default number of redirects to follow", (done) => {
+      const redirects: string[] = [];
+
+      const app = setup();
+
+      superdeno(app)
+        .get("/")
+        .redirects(2)
+        .on("redirect", (res) => {
+          redirects.push(res.headers.location);
+        })
+        .end((err, res) => {
+          try {
+            const arr = [];
+            expect(res.redirect).toBeDefined();
+            arr.push("/movies");
+            arr.push("/movies/all");
+            expect(redirects).toEqual(arr);
+            expect(res.statusText).toMatch(/Moved Temporarily|Found/);
+            done();
+          } catch (e) {
+            done(e);
+          }
+        });
+    });
+  });
+
+  describe("on POST", () => {
+    it("should redirect as GET", async () => {
+      const redirects: string[] = [];
+
+      const app = setup();
+
+      return await superdeno(app)
+        .post("/movie")
+        .send({ name: "Smudgie" })
+        .redirects(2)
+        .on("redirect", (res) => {
+          redirects.push(res.headers.location);
+        })
+        .then((res) => {
+          expect(redirects).toEqual(["/movies/all/0"]);
+          expect(res.text).toEqual("first movie page");
+        });
+    });
+
+    it("using multipart/form-data should redirect as GET", async () => {
+      const redirects: string[] = [];
+
+      const app = setup();
+
+      return await superdeno(app)
+        .post("/movie")
+        .type("form")
+        .field("name", "Smudgie")
+        .redirects(2)
+        .on("redirect", (res) => {
+          redirects.push(res.headers.location);
+        })
+        .then((res) => {
+          expect(redirects).toEqual(["/movies/all/0"]);
+          expect(res.text).toEqual("first movie page");
+        });
+    });
+  });
+
+  describe("on 303", () => {
+    it("should redirect with same method", (done) => {
+      const app = setup();
+
+      superdeno(app)
+        .put("/redirect-303")
+        .send({ msg: "hello" })
+        .redirects(1)
+        .on("redirect", (res) => {
+          expect(res.headers.location).toEqual("/reply-method");
+        })
+        .end((err, res) => {
+          if (err) {
+            done(err);
+
+            return;
+          }
+
+          expect(res.text).toEqual("method=get");
+          done();
+        });
+    });
+  });
+
+  describe("on 307", () => {
+    it("should redirect with same method", (done) => {
+      const app = setup();
+
+      superdeno(app)
+        .put("/redirect-307")
+        .send({ msg: "hello" })
+        .redirects(1)
+        .on("redirect", (res) => {
+          expect(res.headers.location).toEqual("/reply-method");
+        })
+        .end((err, res) => {
+          if (err) {
+            done(err);
+
+            return;
+          }
+
+          expect(res.text).toEqual("method=put");
+          done();
+        });
+    });
+  });
+
+  describe("on 308", () => {
+    it("should redirect with same method", (done) => {
+      const app = setup();
+
+      superdeno(app)
+        .put("/redirect-308")
+        .send({ msg: "hello" })
+        .redirects(1)
+        .on("redirect", (res) => {
+          expect(res.headers.location).toEqual("/reply-method");
+        })
+        .end((err, res) => {
+          if (err) {
+            done(err);
+            return;
+          }
+
+          expect(res.text).toEqual("method=put");
+          done();
+        });
+    });
+  });
+});

--- a/test/supertest.opine.test.ts
+++ b/test/supertest.opine.test.ts
@@ -199,7 +199,7 @@ describe("superdeno(app)", () => {
       .expect("Hello", done);
   });
 
-  it("should default redirects to 0", (done) => {
+  it("superdeno(app): should default redirects to 0", (done) => {
     const app = opine();
 
     app.get("/", (req, res) => {
@@ -211,30 +211,63 @@ describe("superdeno(app)", () => {
       .expect(302, done);
   });
 
-  // TODO: why is this throwing "Error: Request has been terminated"
-  // instead of returning the 302 response!
-  // it("should handle intermediate redirects", (done) => {
-  //   const app = opine();
+  it("superdeno(app): promise form: should default redirects to 0", async () => {
+    const app = opine();
 
-  //   app.get("/login", (req, res) => {
-  //     res.end("Login");
-  //   });
+    app.get("/", (req, res) => {
+      res.redirect("/login");
+    });
 
-  //   app.get("/redirect", (req, res) => {
-  //     res.redirect("/login");
-  //   });
+    await superdeno(app)
+      .get("/")
+      .expect(302);
+  });
 
-  //   app.get("/", (req, res) => {
-  //     res.redirect("/redirect");
-  //   });
+  it("superdeno(app): .redirects(n): should handle intermediate redirects", (
+    done,
+  ) => {
+    const app = opine();
 
-  //   superdeno(app)
-  //     .get("/")
-  //     .redirects(1)
-  //     .expect(302, done);
-  // });
+    app.get("/login", (req, res) => {
+      res.end("Login");
+    });
 
-  it("should handle full redirects", (done) => {
+    app.get("/redirect", (req, res) => {
+      res.redirect("/login");
+    });
+
+    app.get("/", (req, res) => {
+      res.redirect("/redirect");
+    });
+
+    superdeno(app)
+      .get("/")
+      .redirects(1)
+      .expect(302, done);
+  });
+
+  it("superdeno(app): .redirects(n): promise form: should handle intermediate redirects", async () => {
+    const app = opine();
+
+    app.get("/login", (req, res) => {
+      res.end("Login");
+    });
+
+    app.get("/redirect", (req, res) => {
+      res.redirect("/login");
+    });
+
+    app.get("/", (req, res) => {
+      res.redirect("/redirect");
+    });
+
+    await superdeno(app)
+      .get("/")
+      .redirects(1)
+      .expect(302);
+  });
+
+  it("superdeno(app): .redirects(n): should handle full redirects", (done) => {
     const app = opine();
 
     app.get("/login", (req, res) => {
@@ -258,6 +291,30 @@ describe("superdeno(app)", () => {
         expect(res.text).toEqual("Login");
         done();
       });
+  });
+
+  it("superdeno(app): .redirects(n): promise form: should handle full redirects", async () => {
+    const app = opine();
+
+    app.get("/login", (req, res) => {
+      res.end("Login");
+    });
+
+    app.get("/redirect", (req, res) => {
+      res.redirect("/login");
+    });
+
+    app.get("/", (req, res) => {
+      res.redirect("/redirect");
+    });
+
+    const res = await superdeno(app)
+      .get("/")
+      .redirects(2);
+
+    expect(res).toBeDefined();
+    expect(res.status).toEqual(200);
+    expect(res.text).toEqual("Login");
   });
 
   // TODO: figure out the equivalent error scenario for Deno setup

--- a/version.ts
+++ b/version.ts
@@ -1,7 +1,7 @@
 /** 
  * Version of SuperDeno.
  */
-export const VERSION: string = "2.5.0";
+export const VERSION: string = "3.0.0";
 
 /**
  * Supported versions of Deno.


### PR DESCRIPTION
# Issue

Fixes #6

## Details

- Adds support for `res.redirects(n)` API (see https://visionmedia.github.io/superagent/#following-redirects)

## CheckList

- [x] PR starts with [#_ISSUE_ID_].
- [x] Has been tested (where required) before merge to develop.
