### PR TITLE
[#25] Use Deno.inspect instead of npm package

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -9,5 +9,4 @@ export { assertEquals } from "https://deno.land/std@0.85.0/testing/asserts.ts";
 export { methods } from "https://deno.land/x/opine@1.1.0/src/methods.ts";
 export { mergeDescriptors } from "https://deno.land/x/opine@1.1.0/src/utils/mergeDescriptors.ts";
 // TODO: import these as production modules
-export { default as util } from "https://dev.jspm.io/npm:util@0.12.3";
 export { default as superagent } from "https://dev.jspm.io/npm:superagent@6.1.0";

--- a/src/test.ts
+++ b/src/test.ts
@@ -7,7 +7,7 @@
  */
 
 import type { Listener, Server } from "./types.ts";
-import { assertEquals, STATUS_TEXT, util } from "../deps.ts";
+import { assertEquals, STATUS_TEXT } from "../deps.ts";
 import { superagent } from "./superagent.ts";
 import { close } from "./close.ts";
 import { isListener, isServer, isString } from "./utils.ts";
@@ -513,8 +513,8 @@ export class Test extends SuperRequest {
       try {
         assertEquals(body, res.body);
       } catch (err) {
-        const a = (util as any).inspect(body);
-        const b = (util as any).inspect(res.body);
+        const a = Deno.inspect(body);
+        const b = Deno.inspect(res.body);
 
         return error(
           `expected ${a} response body, got ${b}`,
@@ -524,8 +524,8 @@ export class Test extends SuperRequest {
       }
     } else if (body !== res.text) {
       // string
-      const a = (util as any).inspect(body);
-      const b = (util as any).inspect(res.text);
+      const a = Deno.inspect(body);
+      const b = Deno.inspect(res.text);
 
       // regexp
       if (isregexp) {

--- a/test/supertest.opine.test.ts
+++ b/test/supertest.opine.test.ts
@@ -558,7 +558,7 @@ describe("superdeno(app)", () => {
           .get("/")
           .expect(200, "")
           .end((err, res) => {
-            expect(err.message).toEqual("expected '' response body, got 'foo'");
+            expect(err.message).toEqual('expected "" response body, got "foo"');
             done();
           });
       });
@@ -582,7 +582,7 @@ describe("superdeno(app)", () => {
         .expect("hey")
         .end((err, res) => {
           expect(err.message).toEqual(
-            "expected 'hey' response body, got '{\"foo\":\"bar\"}'",
+            'expected "hey" response body, got \'{"foo":"bar"}\'',
           );
           done();
         });
@@ -643,7 +643,7 @@ describe("superdeno(app)", () => {
         .expect({ foo: "baz" })
         .end((err, res) => {
           expect(err.message).toEqual(
-            "expected { foo: 'baz' } response body, got { foo: 'bar' }",
+            'expected { foo: "baz" } response body, got { foo: "bar" }',
           );
 
           superdeno(app)
@@ -692,7 +692,7 @@ describe("superdeno(app)", () => {
         )
         .end((err, res) => {
           expect(err.message).toEqual(
-            "expected { stringValue: 'foo',\n  numberValue: 3,\n  nestedObject: { innerString: 5 } } response body, got { stringValue: 'foo',\n  numberValue: 3,\n  nestedObject: { innerString: '5' } }",
+            'expected { stringValue: "foo", numberValue: 3, nestedObject: { innerString: 5 } } response body, got { stringValue: "foo", numberValue: 3, nestedObject: { innerString: "5" } }',
           ); // eslint-disable-line max-len
 
           superdeno(app)
@@ -721,7 +721,7 @@ describe("superdeno(app)", () => {
         .get("/")
         .expect(/^bar/)
         .end((err, res) => {
-          expect(err.message).toEqual("expected body 'foobar' to match /^bar/");
+          expect(err.message).toEqual('expected body "foobar" to match /^bar/');
           done();
         });
     });
@@ -742,7 +742,7 @@ describe("superdeno(app)", () => {
         .expect("hey deno")
         .end((err, res) => {
           expect(err.message).toEqual(
-            "expected 'hey' response body, got 'hey deno'",
+            'expected "hey" response body, got "hey deno"',
           );
           done();
         });


### PR DESCRIPTION
# Issue

Closes #25 

## Details

An NPM library was being used to provide node's util functionality, which brings in a total of 16 NPM packages. Deno includes a built-in function `Deno.inspect` which provides nearly the same output, so this PR removes the `util` import in favor of using `Deno.inspect()` directly.

The new messages are showing a different quote-character preference, and one of the tests uses an object which no longer includes newlines. I've adjusted all the test expectations so the changes are visible in this PR.

## CheckList

- [x] PR starts with [#_ISSUE_ID_].
- [x] Has been tested (where required) before merge to develop.

⬆️ develop? The primary branch here is main 😄 