### PR TITLE
deps: bump deps and replace std@0.106 with http_legacy.ts

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,6 +1,6 @@
-export { Server } from "https://deno.land/std@0.107.0/http/server.ts";
-export { STATUS_TEXT } from "https://deno.land/std@0.107.0/http/http_status.ts";
-export { assertEquals } from "https://deno.land/std@0.107.0/testing/asserts.ts";
-export { methods } from "https://deno.land/x/opine@1.7.2/src/methods.ts";
-export { mergeDescriptors } from "https://deno.land/x/opine@1.7.2/src/utils/mergeDescriptors.ts";
+export { Server } from "https://deno.land/std@0.109.0/http/server.ts";
+export { STATUS_TEXT } from "https://deno.land/std@0.109.0/http/http_status.ts";
+export { assertEquals } from "https://deno.land/std@0.109.0/testing/asserts.ts";
+export { methods } from "https://deno.land/x/opine@1.8.0/src/methods.ts";
+export { mergeDescriptors } from "https://deno.land/x/opine@1.8.0/src/utils/mergeDescriptors.ts";
 export { default as superagent } from "https://jspm.dev/superagent@6.1.0";

--- a/test/deps.ts
+++ b/test/deps.ts
@@ -1,5 +1,5 @@
-export { dirname, join } from "https://deno.land/std@0.107.0/path/mod.ts";
+export { dirname, join } from "https://deno.land/std@0.109.0/path/mod.ts";
 export { expect } from "https://deno.land/x/expect@v0.2.9/mod.ts";
-export * as Opine from "https://deno.land/x/opine@1.7.2/mod.ts";
+export * as Opine from "https://deno.land/x/opine@1.8.0/mod.ts";
 export * as Oak from "https://deno.land/x/oak@v9.0.1/mod.ts";
 export { getFreePort } from "https://deno.land/x/free_port@v1.2.0/mod.ts";

--- a/test/superdeno.opine.test.ts
+++ b/test/superdeno.opine.test.ts
@@ -91,11 +91,12 @@ describe("superdeno(app)", () => {
       res.send("hey");
     });
 
-    const server = app.listen(4001);
+    const server = app.listen(4002);
 
-    superdeno("http://localhost:4001")
+    superdeno("http://localhost:4002")
       .get("/")
-      .end((_err, res) => {
+      .end((err, res) => {
+        if (err) throw err;
         expect(res.status).toEqual(200);
         expect(res.text).toEqual("hey");
         server.close();

--- a/test/superdeno.std_legacy.test.ts
+++ b/test/superdeno.std_legacy.test.ts
@@ -1,4 +1,4 @@
-import { serve } from "https://deno.land/std@0.106.0/http/server.ts";
+import { serve } from "https://deno.land/std@0.109.0/http/server_legacy.ts";
 import { describe, it } from "./utils.ts";
 import { superdeno } from "../mod.ts";
 


### PR DESCRIPTION
## Details

This PR upgrades dependencies and switches `std@0.106.0/node/http.ts` to `http_legacy.ts`

also i had to switch port from 4001 to 4002 in one test case because 4001 is reserved by IPFS

## CheckList

- [ ] PR starts with [#_ISSUE_ID_]. (there's no issue)
- [x] Has been tested (where required) before merge to main.
