### PR TITLE
[#36] fix: process FormData correctly

### DIFF
--- a/src/xhrSham.js
+++ b/src/xhrSham.js
@@ -268,12 +268,11 @@ export class XMLHttpRequestSham {
       return xhr.onreadystatechange();
     } else {
       try {
-        const body =
-          typeof options.requestBody === "object" &&
-          !(options.requestBody instanceof FormData) &&
-          options.requestBody !== null
-            ? JSON.stringify(options.requestBody)
-            : options.requestBody;
+        const body = typeof options.requestBody === "object" &&
+            !(options.requestBody instanceof FormData) &&
+            options.requestBody !== null
+          ? JSON.stringify(options.requestBody)
+          : options.requestBody;
 
         // We set the fetch promise into a polyfill promise cache
         // so that superdeno can await these promises before ending.

--- a/src/xhrSham.js
+++ b/src/xhrSham.js
@@ -268,10 +268,12 @@ export class XMLHttpRequestSham {
       return xhr.onreadystatechange();
     } else {
       try {
-        const body = typeof options.requestBody === "object" &&
-            options.requestBody !== null
-          ? JSON.stringify(options.requestBody)
-          : options.requestBody;
+        const body =
+          typeof options.requestBody === "object" &&
+          !(options.requestBody instanceof FormData) &&
+          options.requestBody !== null
+            ? JSON.stringify(options.requestBody)
+            : options.requestBody;
 
         // We set the fetch promise into a polyfill promise cache
         // so that superdeno can await these promises before ending.

--- a/test/form-data.test.ts
+++ b/test/form-data.test.ts
@@ -1,0 +1,67 @@
+import { Oak, Opine } from "./deps.ts";
+import { describe, it } from "./utils.ts";
+import {
+  assertStrictEquals,
+  assertStringIncludes,
+} from "https://deno.land/std@0.113.0/testing/asserts.ts";
+import { superdeno } from "../mod.ts";
+
+const setupOak = () => {
+  const app = new Oak.Application();
+  const router = new Oak.Router();
+
+  router.post("/", (ctx) => {
+    const headers = ctx.request.headers;
+    const body = ctx.request.body();
+
+    assertStringIncludes(
+      headers.get("content-type") ?? "",
+      "multipart/form-data; boundary=",
+    );
+    assertStrictEquals(body.type, "form-data");
+
+    ctx.response.status = 200;
+  });
+
+  app.use(router.allowedMethods());
+  app.use(router.routes());
+
+  return app;
+};
+
+const setupOpine = () => {
+  const app = Opine.opine();
+
+  app.post("/", (req, res) => {
+    assertStringIncludes(
+      req.headers.get("content-type") ?? "",
+      "multipart/form-data; boundary=",
+    );
+
+    res.send("done");
+  });
+
+  return app;
+};
+
+describe("post multipart/form-data", async () => {
+  it("should work with oak", async () => {
+    const app = setupOak();
+
+    await superdeno(app.handle.bind(app))
+      .post("/")
+      .field("form_key", "form_value")
+      .attach("file_key", "path_to_file", "filename")
+      .expect(200);
+  });
+
+  it("should work with opine", async () => {
+    const app = setupOpine();
+
+    await superdeno(app)
+      .post("/")
+      .field("form_key", "form_value")
+      .attach("file_key", "path_to_file", "filename")
+      .expect(200);
+  });
+});

--- a/test/form-data.test.ts
+++ b/test/form-data.test.ts
@@ -44,7 +44,7 @@ const setupOpine = () => {
   return app;
 };
 
-describe("post multipart/form-data", async () => {
+describe("post multipart/form-data", () => {
   it("should work with oak", async () => {
     const app = setupOak();
 


### PR DESCRIPTION
# Issue

Fixes #36 

## Details

When calling fetch API in xhrSham.js, pass FormData directly to fetch instead of stringifying it.

## CheckList

- [x] PR starts with #36 
- [x] Has been tested (where required) before merge to main.
